### PR TITLE
Use APCU instead of classmap for composer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY src src/
 COPY var var/
 COPY web web/
 
-RUN composer dump-autoload --optimize --classmap-authoritative --no-dev
+RUN composer dump-autoload --optimize --apcu-autoloader --no-dev
 
 COPY docker/php/start.sh /usr/local/bin/docker-app-start
 

--- a/docker/php/start.sh
+++ b/docker/php/start.sh
@@ -5,7 +5,7 @@ set -xe
 export DOCKER_BRIDGE_IP=$(ip ro | grep default | cut -d' ' -f 3)
 
 if [ "APP_ENV" = 'prod' ]; then
-	composer install --prefer-dist --no-dev --no-progress --no-suggest --optimize-autoloader --classmap-authoritative
+	composer install --prefer-dist --no-dev --no-progress --no-suggest --optimize-autoloader --apcu-autoloader
 else
 	composer install --prefer-dist --no-progress --no-suggest
 fi


### PR DESCRIPTION
As you sweat to install APCU in the docker image, I think it might be a better idea to rely on apcu for autoload rather than classmap, because we can't use both, and apcu might be faster because memory.

What do you think?